### PR TITLE
Update footer copyright year to 2026

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -48,7 +48,7 @@
     <div class="container">
       <div class="contact-info">
         <p><strong>Want to get in touch?</strong> Drop me an email at <a
-            href="mailto:me@timrogers.co.uk">me@timrogers.co.uk</a>. &copy; Tim Rogers 2025</p>
+            href="mailto:me@timrogers.co.uk">me@timrogers.co.uk</a>. &copy; Tim Rogers 2026</p>
         <div class="social-links">
           <a href="https://github.com/timrogers" target="_blank" aria-label="@timrogers on GitHub" class="social-link">
             <img src="/images/GitHub-Mark-120px-plus.png" alt="GitHub logo" width="24px" class="img-icon" />


### PR DESCRIPTION
### Motivation
- Keep the site footer copyright date current by moving the year forward to 2026.
- This is a small content update limited to the site layout so visitors see an up-to-date copyright notice.

### Description
- Updated the footer copyright year from `2025` to `2026` in the layout file ` _layouts/default.html`.
- The change is limited to the single line in ` _layouts/default.html` and does not alter site logic or assets.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696129f8b02c832cba0a593f7bf8b682)