### PR TITLE
Add placeholder broken external link to homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,8 +7,4 @@ layout: default
 
   {% include portfolio-list.html %}
 
-  <p class="u-marginTm">
-    Curious about an experimental resource? Check out
-    <a href="https://nonexistent-project.faketown.invalid">this prototype link</a>.
-  </p>
 </div>

--- a/index.html
+++ b/index.html
@@ -6,4 +6,9 @@ layout: default
   <h2 class="u-paddingAs u-marginTm">What I've worked on</h2>
 
   {% include portfolio-list.html %}
+
+  <p class="u-marginTm">
+    Curious about an experimental resource? Check out
+    <a href="https://nonexistent-project.faketown.invalid">this prototype link</a>.
+  </p>
 </div>


### PR DESCRIPTION
### Motivation
- Introduce a deliberately broken external URL on the homepage to simulate a missing external resource for link-checking or demo purposes.
- Provide a simple, visible example of how an external link to a non-existent domain is rendered on the site.

### Description
- Update `index.html` to insert a new paragraph below the portfolio list containing an anchor to `https://nonexistent-project.faketown.invalid`.
- The new paragraph uses the `u-marginTm` class and the anchor text is "this prototype link".
- No other files were modified.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69612fd44e84832cbcba7efca4a6a7c1)