### PR TITLE
Restore placeholder external link on homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,5 +11,4 @@ layout: default
     Curious about an experimental resource? Check out
     <a href="https://nonexistent-project.faketown.invalid">this prototype link</a>.
   </p>
-
 </div>

--- a/index.html
+++ b/index.html
@@ -6,4 +6,10 @@ layout: default
   <h2 class="u-paddingAs u-marginTm">What I've worked on</h2>
 
   {% include portfolio-list.html %}
+
+  <p class="u-marginTm">
+    Curious about an experimental resource? Check out
+    <a href="https://nonexistent-project.faketown.invalid">this prototype link</a>.
+  </p>
+
 </div>


### PR DESCRIPTION
### Motivation
- Re-add the intentionally included placeholder external link so the homepage content matches the original example and the prototype reference is present.

### Description
- Inserted a paragraph with an anchor to `https://nonexistent-project.faketown.invalid` into `index.html` to restore the removed prototype link.

### Testing
- Started a local server with `python -m http.server` and used Playwright to load `http://127.0.0.1:8000/` and capture a screenshot, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69612fd44e84832cbcba7efca4a6a7c1)